### PR TITLE
Update wazero, allow overwriting runtime config

### DIFF
--- a/descriptors/wasm.go
+++ b/descriptors/wasm.go
@@ -34,6 +34,11 @@ var wasmBytes []byte
 
 var initOnce sync.Once
 
+// WazeroRuntimeConfig is the runtime configuration used when the WASM parser
+// is initialized for the very first time. Must be overwritten before the first
+// public function of this module is called.
+var WazeroRuntimeConfig = wazero.NewRuntimeConfig()
+
 type wasmModule struct {
 	mod api.Module
 	// `Call()` is not goroutine-safe, see
@@ -568,7 +573,9 @@ func logString(_ context.Context, m api.Module, offset, byteCount uint32) {
 func getWasmMod() *wasmModule {
 	initOnce.Do(func() {
 		ctx := context.Background()
-		wasmRuntime := wazero.NewRuntime(ctx)
+		wasmRuntime := wazero.NewRuntimeWithConfig(
+			ctx, WazeroRuntimeConfig,
+		)
 		wasi_snapshot_preview1.MustInstantiate(ctx, wasmRuntime)
 		_, err := wasmRuntime.NewHostModuleBuilder("env").
 			NewFunctionBuilder().

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,15 @@
 module github.com/benma/descriptors-go
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.9.0
-	github.com/tetratelabs/wazero v1.8.1
+	github.com/tetratelabs/wazero v1.11.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.38.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tetratelabs/wazero v1.8.1 h1:NrcgVbWfkWvVc4UtT4LRLDf91PsOzDzefMdwhLfA550=
-github.com/tetratelabs/wazero v1.8.1/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
+github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbwqYhA=
+github.com/tetratelabs/wazero v1.11.0/go.mod h1:eV28rsN8Q+xwjogd7f4/Pp4xFxO7uOGbLcD/LzB1wiU=
+golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
This PR updates the `wazero` library to version `v1.11.0` and allows its runtime configuration to be overwritten.
Without the ability to set the runtime configuration to explicitly use the compiler, it falls back to the interpreter on `gomobile` environments, which is significantly slower.
The compiler is supported on `amd64` and `arm64`, so most mobile phones should just work with the compiler if we can set it explicitly using this PR.

On a Pixel 9 this reduces a call from almost a second to a couple of milliseconds.

More details: https://github.com/wazero/wazero#compiler